### PR TITLE
fixed filter column name in program entity

### DIFF
--- a/classes/reportbuilder/local/entities/program.php
+++ b/classes/reportbuilder/local/entities/program.php
@@ -278,7 +278,7 @@ final class program extends base {
             'fullname',
             new lang_string('programname', 'tool_muprog'),
             $this->get_entity_name(),
-            "{$programalias}.name"
+            "{$programalias}.fullname"
         ))
             ->add_joins($this->get_joins());
 


### PR DESCRIPTION
When filtering programs, filtering by name did not work because it expected the wrong column name.